### PR TITLE
Assign compiler flags into the correct variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,11 +3,11 @@ if "msvc" in env["TOOLS"]:
 	#env.AppendUnique(CXXFLAGS=["/O2"])
 	#env.AppendUnique(CXXFLAGS=["/DEBUG"])
 	env.AppendUnique(CXXFLAGS=["/EHsc"])
-	libraries = ""
 elif "clangxx" in env["TOOLS"] or "g++" in env["TOOLS"]:
-	env.AppendUnique(CXXFLAGS=["-std=c++14", "-Wall", "-Wpedantic", "-Wextra"])
-	env.AppendUnique(CXXFLAGS=["-g"])
-	libraries = ["pthread"]
+	env.AppendUnique(CCFLAGS=["-Wall", "-Wextra", "-g", "-pedantic", "-pthread"])
+	env.AppendUnique(CFLAGS=["-std=gnu99"])
+	env.AppendUnique(CXXFLAGS=["-std=c++14"])
+	env.AppendUnique(LINKFLAGS=["-pthread"])
 
 env.VariantDir('build', 'src')
 env.AppendUnique(CPPDEFINES=["LUA_COMPAT_5_2"])
@@ -16,4 +16,4 @@ env.AppendUnique(CPPPATH=["src/lua/src"])
 luasrc = Glob("build/lua/src/*.c", exclude="build/lua/src/lua*.c")
 #env.Program("lua", ["build/lua/src/lua.c"] + luasrc)
 #env.Program("luac", ["build/lua/src/luac.c"] + luasrc)
-env.Program("program", ["build/main.cpp"] + luasrc, LIBS = libraries)
+env.Program("program", ["build/main.cpp"] + luasrc)


### PR DESCRIPTION
Pass -pthread for compilation and linking as this is a more general way to
build multi-threaded code than just linking to -lpthread.

Fix build of lua and luac (if uncommented) by using identical environments
for all compiler invocations.