### PR TITLE
Extend peglib's enter and leave and introduce get_rule_names()

### DIFF
--- a/src/luautils.h
+++ b/src/luautils.h
@@ -53,19 +53,18 @@ inline auto lua_loadutils(lua_State *L){
 	const auto utils = R"(
 
 	function stringify(o)
-	   if type(o) == 'table' then
-		  local s = '{ '
-		  for k,v in pairs(o) do
-		     if type(k) ~= 'number' then k = ''..k..'' end
-		     s = s .. '['..k..'] = ' .. stringify(v) .. ','
-		  end
-		  return s .. '} '
-	   else
-		  return tostring(o)
-	   end
+		if type(o) == 'table' then
+			local s = '{ '
+			for k,v in pairs(o) do
+				if type(k) ~= 'number' then k = ''..k..'' end
+				s = s .. '['..k..'] = ' .. stringify(v) .. ','
+			end
+			return s .. '} '
+		else
+			return tostring(o)
+		end
 	end
 
 	)";
 	return luaL_loadstring(L, utils) || lua_pcall(L, 0, 0, 0);
 }
-

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -1,0 +1,53 @@
+
+#pragma once
+
+#include <string>
+#include "lua/src/lua.hpp"
+
+using namespace std;
+
+// utilities for lua stack manipulation
+struct LuaStackPtr{
+	LuaStackPtr(const int idx_):idx(idx_){}
+	const int idx;
+};
+
+struct StringPtr{
+	StringPtr(const char* c_, const size_t len_):c(c_),len(len_){}
+	const char* c;
+	const size_t len;
+};
+
+void lua_push(lua_State *L, const int value){
+	lua_pushinteger(L, value);
+}
+void lua_push(lua_State *L, const string value){
+	lua_pushstring(L, value.c_str());
+}
+void lua_push(lua_State *L, const char *value){
+	lua_pushstring(L, value);
+}
+void lua_push(lua_State *L, const StringPtr value){
+	lua_pushlstring(L, value.c, value.len);
+}
+void lua_push(lua_State *L, const LuaStackPtr value){
+	lua_pushvalue(L, value.idx);
+}
+
+void lua_closefield(lua_State *L){
+	lua_settable(L, -3);
+}
+
+template<typename TKey, typename TVal>
+void lua_pushfield(lua_State *L, const TKey key, const TVal value){
+	lua_push(L, key);
+	lua_push(L, value);
+	lua_closefield(L);
+}
+
+template<typename TKey>
+void lua_opensubtable(lua_State *L, const TKey key){
+	lua_push(L, key);
+	lua_newtable(L);
+}
+

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -11,9 +11,9 @@ struct LuaStackPtr{
 };
 
 struct StringPtr{
-	StringPtr(const char* c_, const size_t len_):c(c_),len(len_){}
+	StringPtr(const char* c_, const std::size_t len_):c(c_),len(len_){}
 	const char* c;
-	const size_t len;
+	const std::size_t len;
 };
 
 void lua_push(lua_State *L, const int value){

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -51,3 +51,23 @@ void lua_opensubtable(lua_State *L, const TKey key){
 	lua_newtable(L);
 }
 
+auto lua_loadutils(lua_State *L){
+	const auto utils = R"(
+
+	function stringify(o)
+	   if type(o) == 'table' then
+		  local s = '{ '
+		  for k,v in pairs(o) do
+		     if type(k) ~= 'number' then k = ''..k..'' end
+		     s = s .. '['..k..'] = ' .. stringify(v) .. ','
+		  end
+		  return s .. '} '
+	   else
+		  return tostring(o)
+	   end
+	end
+
+	)";
+	return luaL_loadstring(L, utils) || lua_pcall(L, 0, 0, 0);
+}
+

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -11,15 +11,15 @@ struct LuaStackPtr{
 };
 
 struct StringPtr{
-	StringPtr(const char* c_, const std::size_t len_):c(c_),len(len_){}
-	const char* c;
+	StringPtr(const char* const c_, const std::size_t len_):c(c_),len(len_){}
+	const char* const c;
 	const std::size_t len;
 };
 
 void lua_push(lua_State *L, const int value){
 	lua_pushinteger(L, value);
 }
-void lua_push(lua_State *L, const std::string value){
+void lua_push(lua_State *L, const std::string& value){
 	lua_pushstring(L, value.c_str());
 }
 void lua_push(lua_State *L, const char *value){

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -6,7 +6,7 @@
 
 // utilities for lua stack manipulation
 struct LuaStackPtr{
-	LuaStackPtr(const int idx_):idx(idx_){}
+	explicit LuaStackPtr(const int idx_):idx(idx_){}
 	const int idx;
 };
 

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -25,7 +25,7 @@ void lua_push(lua_State *L, const std::string& value){
 void lua_push(lua_State *L, const char *value){
 	lua_pushstring(L, value);
 }
-void lua_push(lua_State *L, const StringPtr value){
+void lua_push(lua_State *L, const StringPtr& value){
 	lua_pushlstring(L, value.c, value.len);
 }
 void lua_push(lua_State *L, const LuaStackPtr value){
@@ -37,14 +37,14 @@ void lua_closefield(lua_State *L){
 }
 
 template<typename TKey, typename TVal>
-void lua_pushfield(lua_State *L, const TKey key, const TVal value){
+void lua_pushfield(lua_State *L, const TKey& key, const TVal& value){
 	lua_push(L, key);
 	lua_push(L, value);
 	lua_closefield(L);
 }
 
 template<typename TKey>
-void lua_opensubtable(lua_State *L, const TKey key){
+void lua_opensubtable(lua_State *L, const TKey& key){
 	lua_push(L, key);
 	lua_newtable(L);
 }

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -20,7 +20,7 @@ void lua_push(lua_State *L, const int value){
 	lua_pushinteger(L, value);
 }
 void lua_push(lua_State *L, const std::string& value){
-	lua_pushstring(L, value.c_str());
+	lua_pushlstring(L, value.data(), value.size());
 }
 void lua_push(lua_State *L, const char *value){
 	lua_pushstring(L, value);

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -4,8 +4,6 @@
 #include <string>
 #include "lua/src/lua.hpp"
 
-using namespace std;
-
 // utilities for lua stack manipulation
 struct LuaStackPtr{
 	LuaStackPtr(const int idx_):idx(idx_){}
@@ -21,7 +19,7 @@ struct StringPtr{
 void lua_push(lua_State *L, const int value){
 	lua_pushinteger(L, value);
 }
-void lua_push(lua_State *L, const string value){
+void lua_push(lua_State *L, const std::string value){
 	lua_pushstring(L, value.c_str());
 }
 void lua_push(lua_State *L, const char *value){

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -16,40 +16,40 @@ struct StringPtr{
 	const std::size_t len;
 };
 
-void lua_push(lua_State *L, const int value){
+inline void lua_push(lua_State *L, const int value){
 	lua_pushinteger(L, value);
 }
-void lua_push(lua_State *L, const std::string& value){
+inline void lua_push(lua_State *L, const std::string& value){
 	lua_pushlstring(L, value.data(), value.size());
 }
-void lua_push(lua_State *L, const char *value){
+inline void lua_push(lua_State *L, const char *value){
 	lua_pushstring(L, value);
 }
-void lua_push(lua_State *L, const StringPtr& value){
+inline void lua_push(lua_State *L, const StringPtr& value){
 	lua_pushlstring(L, value.c, value.len);
 }
-void lua_push(lua_State *L, const LuaStackPtr value){
+inline void lua_push(lua_State *L, const LuaStackPtr value){
 	lua_pushvalue(L, value.idx);
 }
 
-void lua_closefield(lua_State *L){
+inline void lua_closefield(lua_State *L){
 	lua_settable(L, -3);
 }
 
 template<typename TKey, typename TVal>
-void lua_pushfield(lua_State *L, const TKey& key, const TVal& value){
+inline void lua_pushfield(lua_State *L, const TKey& key, const TVal& value){
 	lua_push(L, key);
 	lua_push(L, value);
 	lua_closefield(L);
 }
 
 template<typename TKey>
-void lua_opensubtable(lua_State *L, const TKey& key){
+inline void lua_opensubtable(lua_State *L, const TKey& key){
 	lua_push(L, key);
 	lua_newtable(L);
 }
 
-auto lua_loadutils(lua_State *L){
+inline auto lua_loadutils(lua_State *L){
 	const auto utils = R"(
 
 	function stringify(o)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "peglib.h"
 
 #define DEBUG_PARSER
+#define DEBUG_STRLEN 40 // display that many chars of the parsing text in debug output
 
 using namespace peg;
 using namespace std;
@@ -138,7 +139,7 @@ int Main(vector<string> args)
 		
 		parser[r.c_str()].enter = [r](const char* s, size_t n, any& dt) {
 			auto& indent = *dt.get<int*>();
-			cout << repeat("|  ", indent) << r << " => \"" << shorten(string(s, n), 40) << "\"?" << endl;
+			cout << repeat("|  ", indent) << r << " => \"" << shorten(string(s, n), DEBUG_STRLEN) << "\"?" << endl;
 			indent++;
 		};
 
@@ -149,12 +150,12 @@ int Main(vector<string> args)
 			if(success(matchlen)){
 
 				// display "match", the matched string and the result of the reduction
-				cout << "match: \"" << shorten(string(s, matchlen), 40) << "\" -> ";
+				cout << "match: \"" << shorten(string(s, min(matchlen, (size_t)DEBUG_STRLEN-2)), DEBUG_STRLEN) << "\" -> ";
 				lua_getglobal(L, "stringify");
 				lua_push(L, value.get<LuaStackPtr>());
 				lua_pcall(L, 1, 1, 0);
 				string output = lua_tostring(L, -1);
-				cout << shorten(output, 40) << endl;
+				cout << shorten(output, DEBUG_STRLEN) << endl;
 			}
 			else{
 				cout << "failed" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,14 +28,14 @@ int Main(vector<string> args)
 	luaL_openlibs(L);
 
 	// load custom lua utility library
-	result = lua_loadutils(L);
+	auto result = lua_loadutils(L);
 	if (result){
 		cerr << "error loading lua utils";
 		return EXIT_FAILURE;
-	}	
+	}		
 	
 	// load parser script
-	auto result = luaL_loadfile(L, args[1].c_str()) || lua_pcall(L, 0, 0, 0);
+	result = luaL_loadfile(L, args[1].c_str()) || lua_pcall(L, 0, 0, 0);
 	if (result){
 		cerr << "error loading \"" << args[1] << "\": " << lua_tostring(L, -1) << endl;
 		return EXIT_FAILURE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,7 @@ int Main(vector<string> args)
 				lua_push(L, value.get<LuaStackPtr>());
 				lua_pcall(L, 1, 1, 0);
 				string output = lua_tostring(L, -1);
+				lua_pop(L, 1);
 				cout << shorten(output.data(), output.size(), DEBUG_STRLEN) << endl;
 			}
 			else{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,7 +139,7 @@ int Main(vector<string> args)
 		
 		parser[r.c_str()].enter = [r](const char* s, size_t n, any& dt) {
 			auto& indent = *dt.get<int*>();
-			cout << repeat("|  ", indent) << r << " => \"" << shorten(string(s, n), DEBUG_STRLEN) << "\"?" << endl;
+			cout << repeat("|  ", indent) << r << " => \"" << shorten(s, n, DEBUG_STRLEN) << "\"?" << endl;
 			indent++;
 		};
 
@@ -150,12 +150,12 @@ int Main(vector<string> args)
 			if(success(matchlen)){
 
 				// display "match", the matched string and the result of the reduction
-				cout << "match: \"" << shorten(string(s, min(matchlen, (size_t)DEBUG_STRLEN-2)), DEBUG_STRLEN) << "\" -> ";
+				cout << "match: \"" << shorten(s, matchlen, DEBUG_STRLEN-2) << "\" -> ";
 				lua_getglobal(L, "stringify");
 				lua_push(L, value.get<LuaStackPtr>());
 				lua_pcall(L, 1, 1, 0);
 				string output = lua_tostring(L, -1);
-				cout << shorten(output, DEBUG_STRLEN) << endl;
+				cout << shorten(output.data(), output.size(), DEBUG_STRLEN) << endl;
 			}
 			else{
 				cout << "failed" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,8 +33,8 @@ int Main(vector<string> args)
 	if (result){
 		cerr << "error loading lua utils";
 		return EXIT_FAILURE;
-	}		
-	
+	}
+
 	// load parser script
 	result = luaL_loadfile(L, args[1].c_str()) || lua_pcall(L, 0, 0, 0);
 	if (result){
@@ -47,8 +47,8 @@ int Main(vector<string> args)
 	if(textfile.fail()){
 		cerr << "error loading \"" << args[2] << "\": file not found" << endl;
 		return EXIT_FAILURE;
-    }
-	string text { istreambuf_iterator<char>(textfile), istreambuf_iterator<char>() };	
+	}
+	string text { istreambuf_iterator<char>(textfile), istreambuf_iterator<char>() };
 
 	// copy grammar from parser script
 	lua_getglobal(L, "grammar");
@@ -85,7 +85,7 @@ int Main(vector<string> args)
 		if(funcName != ""){ // use the specified function or the default function from the lua script
 			parser[rule.c_str()] = [&L, rule, funcName](const SemanticValues& sv, any& dt){
 
-				// find function				
+				// find function
 				lua_getglobal(L, funcName.c_str());
 
 				// push input parameters on stack
@@ -96,18 +96,18 @@ int Main(vector<string> args)
 					lua_pushfield(L, "column",  sv.line_info().second);
 					lua_pushfield(L, "choice",  sv.choice());
 
-					lua_opensubtable(L, "subnodes"); 
+					lua_opensubtable(L, "subnodes");
 						for (size_t i = 0; i != sv.size(); ++i){
 							lua_pushfield(L, 1+i, sv[i].get<LuaStackPtr>());
 						}
 					lua_closefield(L);
 
-					lua_opensubtable(L, "tokens"); 
+					lua_opensubtable(L, "tokens");
 						for (size_t i = 0; i != sv.tokens.size(); ++i) {
 							lua_pushfield(L, 1+i, StringPtr(sv.tokens[i].first, sv.tokens[i].second));
 						}
 					lua_closefield(L);
-				
+
 				// call lua function
 				if (lua_pcall(L, 1, 1, 0)){
 					cerr << "error invoking rule: " << lua_tostring(L, -1) << endl;
@@ -136,7 +136,7 @@ int Main(vector<string> args)
 	// assign callbacks for parser debugging
 	#ifdef DEBUG_PARSER
 	for(auto r:rules){
-		
+
 		parser[r.c_str()].enter = [r](const char* s, size_t n, any& dt) {
 			auto& indent = *dt.get<int*>();
 			cout << repeat("|  ", indent) << r << " => \"" << shorten(s, n, DEBUG_STRLEN) << "\"?" << endl;
@@ -175,7 +175,7 @@ int Main(vector<string> args)
 	any dt = &indent;
 
 	bool success = parser.parse(text.c_str(), dt, value);
-	
+
 	if(success){
 		cout << "parsing successful, result = " << lua_tostring(L, value.get<LuaStackPtr>().idx) << endl;
 	}
@@ -196,4 +196,3 @@ int main(int c, char** v){
 #endif
 	return result;
 }
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ int Main(vector<string> args)
 
 				// push input parameters on stack
 				lua_newtable(L);
-					lua_pushfield(L, "rule",    rule.c_str());
+					lua_pushfield(L, "rule",    rule);
 					lua_pushfield(L, "matched", StringPtr(sv.c_str(), sv.length()));
 					lua_pushfield(L, "line",    sv.line_info().first);
 					lua_pushfield(L, "column",  sv.line_info().second);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,11 +90,11 @@ int Main(vector<string> args)
 
 				// push input parameters on stack
 				lua_newtable(L);
-					lua_pushfield(L, "rule",    rule);
+					lua_pushfield(L, "rule", rule);
 					lua_pushfield(L, "matched", StringPtr(sv.c_str(), sv.length()));
-					lua_pushfield(L, "line",    sv.line_info().first);
-					lua_pushfield(L, "column",  sv.line_info().second);
-					lua_pushfield(L, "choice",  sv.choice());
+					lua_pushfield(L, "line", sv.line_info().first);
+					lua_pushfield(L, "column", sv.line_info().second);
+					lua_pushfield(L, "choice", sv.choice());
 
 					lua_opensubtable(L, "subnodes");
 						for (size_t i = 0; i != sv.size(); ++i){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,19 +27,19 @@ int Main(vector<string> args)
 	lua_State *L = luaL_newstate();
 	luaL_openlibs(L);
 
-	// load parser script
-	auto result = luaL_loadfile(L, args[1].c_str()) || lua_pcall(L, 0, 0, 0);
-	if (result){
-		cerr << "error loading \"" << args[1] << "\": " << lua_tostring(L, -1) << endl;
-		return EXIT_FAILURE;
-	}
-
 	// load custom lua utility library
 	result = lua_loadutils(L);
 	if (result){
 		cerr << "error loading lua utils";
 		return EXIT_FAILURE;
 	}	
+	
+	// load parser script
+	auto result = luaL_loadfile(L, args[1].c_str()) || lua_pcall(L, 0, 0, 0);
+	if (result){
+		cerr << "error loading \"" << args[1] << "\": " << lua_tostring(L, -1) << endl;
+		return EXIT_FAILURE;
+	}
 
 	// load text to parse
 	ifstream textfile {args[2]};

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -18,12 +18,12 @@ std::ostream& operator<< (std::ostream& stream, const repeat& rep){
 }
 
 // shorten string and remove line breaks and tabs
-std::string shorten(const std::string& txt, const size_t numchars){
-	std::string result = txt;
+std::string shorten(const char* s, std::size_t len, std::size_t maxlen){
+	std::string result(s, len<maxlen?len:maxlen);
 
 	// shorten
-	if(result.length()>numchars-3){
-		result = result.substr(0,numchars-3) + "...";
+	if(len>maxlen-3){
+		result[maxlen-3] = result[maxlen-2] = result[maxlen-1] = '.';
 	}
 	// replace line breaks and tabs
 	for(auto& c:result){

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <iostream>
+#include <ostream>
 #include <string>
 
 // helper for repeating output
@@ -10,7 +10,7 @@ struct repeat{
 	const char* s;
 	size_t num;
 };
-ostream& operator<< (ostream& stream, const repeat rep){
+std::ostream& operator<< (std::ostream& stream, const repeat rep){
 	for(int i=0; i<rep.num; ++i){
 		stream << rep.s;
 	}
@@ -18,8 +18,8 @@ ostream& operator<< (ostream& stream, const repeat rep){
 }
 
 // shorten string and remove line breaks and tabs
-string shorten(const string& txt, const size_t numchars){
-	string result = txt;
+std::string shorten(const std::string& txt, const size_t numchars){
+	std::string result = txt;
 
 	// shorten
 	if(result.length()>numchars-3){

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -10,7 +10,7 @@ struct repeat{
 	const char* s;
 	size_t num;
 };
-std::ostream& operator<< (std::ostream& stream, const repeat rep){
+std::ostream& operator<< (std::ostream& stream, const repeat& rep){
 	for(int i=0; i<rep.num; ++i){
 		stream << rep.s;
 	}

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -1,0 +1,39 @@
+
+#pragma once
+
+#include <iostream>
+#include <string>
+
+// helper for repeating output
+struct repeat{
+	repeat(const char* s_, size_t num_):s(s_), num(num_){}
+	const char* s;
+	size_t num;
+};
+ostream& operator<< (ostream& stream, const repeat rep){
+	for(int i=0; i<rep.num; ++i){
+		stream << rep.s;
+	}
+	return stream;
+}
+
+// shorten string and remove line breaks and tabs
+string shorten(const string& txt, const size_t numchars){
+	string result = txt;
+
+	// shorten
+	if(result.length()>numchars-3){
+		result = result.substr(0,numchars-3) + "...";
+	}
+	// replace line breaks and tabs
+	for(auto& c:result){
+		if(c == '\n'){
+			c = '\\';
+		}
+		else if(c == '\t'){
+			c = ' ';
+		}
+	}
+
+	return result;
+}

--- a/test/calculator.lua
+++ b/test/calculator.lua
@@ -61,12 +61,12 @@ function MulOp(params)
 end
 
 function Num(params)
-	print("                          ", dump(params))
+	print(dump(params))
 	return params.matched
 end
 
 function default(params)
-	print("                          ", dump(params))
+	print(dump(params))
 	return params.matched
 end
 

--- a/test/calculator.lua
+++ b/test/calculator.lua
@@ -60,10 +60,6 @@ function MulOp(params)
 	end
 end
 
-function Num(params)
-	return params.matched
-end
-
 function default(params)
 	return params.matched
 end

--- a/test/calculator.lua
+++ b/test/calculator.lua
@@ -63,6 +63,3 @@ end
 function default(params)
 	return params.matched
 end
-
-
-

--- a/test/calculator.lua
+++ b/test/calculator.lua
@@ -61,25 +61,12 @@ function MulOp(params)
 end
 
 function Num(params)
-	print(dump(params))
 	return params.matched
 end
 
 function default(params)
-	print(dump(params))
 	return params.matched
 end
 
-function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = ''..k..'' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
-      end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
-end
+
 


### PR DESCRIPTION
Add parameters to the `enter` and `leave` callbacks of grammar rules.

The new method `get_rule_names()` allows setting default actions for all rules in the parsed grammar.
