### PR TITLE
Introduce lua::value

### DIFF
--- a/src/luautils.h
+++ b/src/luautils.h
@@ -32,21 +32,196 @@ inline void lua_push(lua_State *L, const LuaStackPtr value){
 	lua_pushvalue(L, value.idx);
 }
 
-inline void lua_closefield(lua_State *L){
-	lua_settable(L, -3);
+namespace lua {
+	class value;
 }
 
-template<typename TKey, typename TVal>
-void lua_pushfield(lua_State *L, const TKey& key, const TVal& value){
-	lua_push(L, key);
-	lua_push(L, value);
-	lua_closefield(L);
+void lua_push(lua_State* L, const lua::value& value);
+
+namespace lua {
+	namespace detail {
+		template<typename Func>
+		void invoke_with_arg(Func)
+		{}
+
+		template<typename Func, typename Arg0, typename... Args>
+		void invoke_with_arg(Func func, Arg0&& arg0, Args&&... args) {
+			func(std::forward<Arg0>(arg0));
+			return invoke_with_arg(std::move(func), std::forward<Args>(args)...);
+		}
+	}
+
+	class subscript_value;
+
+	/**
+	 * I represent a value of an arbitrary type on the Lua stack.
+	 */
+	class value {
+		static void set_registry(lua_State& L) {
+			lua_settable(&L, LUA_REGISTRYINDEX);
+		}
+
+		static void get_registry(lua_State& L) {
+			lua_gettable(&L, LUA_REGISTRYINDEX);
+		}
+
+	public:
+		/**
+		 * An arbitrary value.
+		 */
+		template<typename TValue>
+		value(lua_State& L, const TValue& val)
+		: m_L(L)
+		{
+			lua_push(&L, val);
+			settable();
+		}
+
+		/**
+		 * Create a value for the current top of the stack.
+		 */
+		explicit value(lua_State& L)
+		: m_L(L)
+		{
+			settable();
+		}
+
+		/**
+		 * Duplicate the given value.
+		 */
+		value(const value& val)
+		: m_L(val.m_L)
+		{
+			val.push();
+			settable();
+		}
+
+		~value() {
+			lua_pushnil(&m_L);
+			settable();
+		}
+
+		lua_State& state() const {
+			return m_L;
+		}
+
+		/**
+		 * Push this value's registry key.
+		 */
+		void key() const {
+			lua_pushlightuserdata(&m_L, const_cast<value*>(this));
+		}
+
+		/**
+		 * Push this value.
+		 */
+		void push() const {
+			key();
+			get_registry(m_L);
+		}
+
+		/**
+		 * Return a LuaStackPtr for this value.
+		 */
+		LuaStackPtr slot() const {
+			push();
+			return LuaStackPtr(lua_gettop(&m_L));
+		}
+
+		/**
+		 * Return a string representation for this value.
+		 */
+		std::string tostring() const {
+			push();
+			std::size_t len;
+			const char* s = lua_tolstring(&m_L, -1, &len);
+			std::string result(s, len);
+			lua_pop(&m_L, 1);
+			return result;
+		}
+
+		/**
+		 * If this value represents a table, set the given slot.
+		 */
+		template<typename TKey, typename TValue>
+		const value& set(const TKey& key, const TValue& value) const {
+			push();
+			lua_push(&m_L, key);
+			lua_push(&m_L, value);
+			lua_settable(&m_L, -3);
+			lua_pop(&m_L, 1);
+			return *this;
+		}
+
+		template<typename TKey>
+		subscript_value operator[](const TKey& key) const;
+
+		/**
+		 * If this value is callable, call it with the given arguments.
+		 */
+		template<typename... Args>
+		value operator()(const Args&... args) const {
+			push();
+			detail::invoke_with_arg(
+				[this](const auto& arg) {
+					lua_push(&m_L, arg);
+				},
+				args...
+			);
+			lua_pcall(&m_L, sizeof...(Args), 1, 0);
+			return value(m_L);
+		}
+
+	private:
+		void settable() {
+			key();
+			lua_rotate(&m_L, -2, 1);
+			set_registry(m_L);
+		}
+
+		lua_State& m_L;
+	};
+
+	inline value getglobal(lua_State& L, const char* name) {
+		lua_getglobal(&L, name);
+		return value(L);
+	}
+
+	inline value newtable(lua_State& L) {
+		lua_newtable(&L);
+		return value(L);
+	}
+
+	/**
+	 * I represent an individual Lua table slot and allow assignment to it.
+	 */
+	class subscript_value {
+	public:
+		template<typename TKey>
+		subscript_value(const value& table, const TKey& key)
+		: m_table(table)
+		, m_key(table.state(), key)
+		{}
+
+		template<typename TValue>
+		const subscript_value& operator=(const TValue& value) const {
+			m_table.set(m_key, value);
+			return *this;
+		}
+
+	private:
+		const value& m_table;
+		const value m_key;
+	};
+
+	template<typename TKey>
+	subscript_value value::operator[](const TKey& key) const {
+		return subscript_value(*this, key);
+	}
 }
 
-template<typename TKey>
-void lua_opensubtable(lua_State *L, const TKey& key){
-	lua_push(L, key);
-	lua_newtable(L);
+inline void lua_push(lua_State*, const lua::value& value) {
+	value.push();
 }
 
 inline auto lua_loadutils(lua_State *L){

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -37,14 +37,14 @@ inline void lua_closefield(lua_State *L){
 }
 
 template<typename TKey, typename TVal>
-inline void lua_pushfield(lua_State *L, const TKey& key, const TVal& value){
+void lua_pushfield(lua_State *L, const TKey& key, const TVal& value){
 	lua_push(L, key);
 	lua_push(L, value);
 	lua_closefield(L);
 }
 
 template<typename TKey>
-inline void lua_opensubtable(lua_State *L, const TKey& key){
+void lua_opensubtable(lua_State *L, const TKey& key){
 	lua_push(L, key);
 	lua_newtable(L);
 }

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -76,6 +76,13 @@ namespace lua {
 		int m_n;
 	};
 
+	/**
+	 * An exception indicating that a Lua error is at the top of the
+	 * stack.
+	 */
+	class exception {
+	};
+
 	class subscript_value;
 
 	/**
@@ -206,6 +213,7 @@ namespace lua {
 
 		/**
 		 * If this value is callable, call it with the given arguments.
+		 * @throw lua::exception on error.
 		 */
 		template<typename... Args>
 		value operator()(const Args&... args) const {
@@ -216,7 +224,9 @@ namespace lua {
 				},
 				args...
 			);
-			lua_pcall(scope::state(), sizeof...(Args), 1, 0);
+			if (LUA_OK != lua_pcall(scope::state(), sizeof...(Args), 1, 0)) {
+				throw exception();
+			}
 			return pop();
 		}
 	};

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -38,8 +38,7 @@ namespace lua {
 			s_L = L;
 		}
 
-		~scope()
-		{
+		~scope() {
 			s_L = m_prev;
 		}
 
@@ -105,7 +104,10 @@ namespace lua {
 			lua_pushlstring(scope::state(), value.c, value.len);
 		}
 
-		static void push(const value& value);
+		static void push(const value& value) {
+			value.push();
+		}
+
 		static void push(const subscript_value& value);
 
 	public:
@@ -155,11 +157,10 @@ namespace lua {
 		}
 
 		/**
-		 * Set our slot in the registry to the value at the top of
-		 * the stack.
+		 * Assign the value at the top of the stack to this object.
 		 */
 		value& assign() {
-			lua_rawsetp(scope::state(), LUA_REGISTRYINDEX, const_cast<value*>(this));
+			lua_rawsetp(scope::state(), LUA_REGISTRYINDEX, this);
 			return *this;
 		}
 
@@ -209,14 +210,14 @@ namespace lua {
 		}
 
 		template<typename TKey>
-		subscript_value operator[](const TKey& key) const;
+		subscript_value operator [](const TKey& key) const;
 
 		/**
 		 * If this value is callable, call it with the given arguments.
 		 * @throw lua::exception on error.
 		 */
 		template<typename... Args>
-		value operator()(const Args&... args) const {
+		value operator ()(const Args&... args) const {
 			push();
 			detail::invoke_with_arg(
 				[this](const auto& arg) {
@@ -230,16 +231,6 @@ namespace lua {
 			return pop();
 		}
 	};
-
-	inline value globals() {
-		lua_pushglobaltable(scope::state());
-		return value::pop();
-	}
-
-	inline value newtable() {
-		lua_newtable(scope::state());
-		return value::pop();
-	}
 
 	/**
 	 * I represent an individual Lua table slot and allow assignment to it.
@@ -268,7 +259,7 @@ namespace lua {
 		 * @param value Value to assign to this table slot.
 		 */
 		template<typename TValue>
-		const subscript_value& operator=(const TValue& value) const {
+		const subscript_value& operator =(const TValue& value) const {
 			m_table.settable(m_key, value);
 			return *this;
 		}
@@ -278,17 +269,23 @@ namespace lua {
 		const value m_key;
 	};
 
-	inline void value::push(const value& value) {
-		value.push();
-	}
-
 	inline void value::push(const subscript_value& value) {
 		value.push();
 	}
 
 	template<typename TKey>
-	subscript_value value::operator[](const TKey& key) const {
+	subscript_value value::operator [](const TKey& key) const {
 		return subscript_value(*this, key);
+	}
+
+	inline value globals() {
+		lua_pushglobaltable(scope::state());
+		return value::pop();
+	}
+
+	inline value newtable() {
+		lua_newtable(scope::state());
+		return value::pop();
 	}
 }
 

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -193,6 +193,15 @@ namespace lua {
 		}
 
 		/**
+		 * Return a C string representation for this value.
+		 */
+		const char* tocstring() const {
+			push();
+			stack_scope ss;
+			return lua_tostring(scope::state(), -1);
+		}
+
+		/**
 		 * If this value represents a table, get the given slot.
 		 */
 		template<typename TKey>
@@ -307,13 +316,13 @@ namespace lua {
 	 * the function via lua::scope. The function receives its arguments on
 	 * the stack and returns a single lua::value.
 	 */
-	template<lua::value(&f)()>
+	template<value (&f)()>
 	int invoke(lua_State* L) {
 		try {
 			const scope luascope(L);
 			f().push();
 			return 1;
-		} catch (lua::exception&) {
+		} catch (exception&) {
 			return lua_error(L);
 		}
 	}

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -263,6 +263,12 @@ namespace lua {
 			return *this;
 		}
 
+		template<typename TKey>
+		subscript_value operator [](const TKey& key) const {
+			push();
+			return value::pop()[key];
+		}
+
 		/**
 		 * @param value Value to assign to this table slot.
 		 */

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -243,11 +243,11 @@ namespace lua {
 		const value m_key;
 	};
 
-	void value::push(const value& value) {
+	inline void value::push(const value& value) {
 		value.push();
 	}
 
-	void value::push(const subscript_value& value) {
+	inline void value::push(const subscript_value& value) {
 		value.push();
 	}
 

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -5,11 +5,6 @@
 #include "lua/src/lua.hpp"
 
 // utilities for lua stack manipulation
-struct LuaStackPtr{
-	explicit LuaStackPtr(const int idx_):idx(idx_){}
-	const int idx;
-};
-
 struct StringPtr{
 	StringPtr(const char* const c_, const std::size_t len_):c(c_),len(len_){}
 	const char* const c;
@@ -32,9 +27,6 @@ inline void lua_push(lua_State *L, const char *value){
 }
 inline void lua_push(lua_State *L, const StringPtr& value){
 	lua_pushlstring(L, value.c, value.len);
-}
-inline void lua_push(lua_State *L, const LuaStackPtr value){
-	lua_pushvalue(L, value.idx);
 }
 void lua_push(lua_State* L, const lua::value& value);
 void lua_push(lua_State* L, const lua::subscript_value& value);
@@ -124,14 +116,6 @@ namespace lua {
 			key();
 			get_registry(m_L);
 			return *this;
-		}
-
-		/**
-		 * Return a LuaStackPtr for this value.
-		 */
-		LuaStackPtr slot() const {
-			push();
-			return LuaStackPtr(lua_gettop(&m_L));
 		}
 
 		/**

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -295,6 +295,32 @@ namespace lua {
 		lua_newtable(scope::state());
 		return value::pop();
 	}
+
+	/**
+	 * Invoke a C++ function from Lua. The Lua state is made available to
+	 * the function via lua::scope. The function receives its arguments on
+	 * the stack and returns a single lua::value.
+	 */
+	template<lua::value(&f)()>
+	int invoke(lua_State* L) {
+		try {
+			const scope luascope(L);
+			f().push();
+			return 1;
+		} catch (lua::exception&) {
+			return lua_error(L);
+		}
+	}
+
+	/**
+	 * This is intended to be used by functions invoked using
+	 * lua::invoke(). It takes an error message and does not return.
+	 */
+	template<typename T>
+	void error(const T& msg) {
+		value(msg).push();
+		throw exception();
+	}
 }
 
 inline auto lua_loadutils(lua_State *L){

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -113,10 +113,17 @@ namespace lua {
 		/**
 		 * Create a value for the current top of the stack.
 		 */
-		value()
-		{
-			set_registry_slot();
+		static value pop() {
+			value result;
+			result.set_registry_slot();
+			return result;
 		}
+
+		/**
+		 * A nil value.
+		 */
+		value()
+		{}
 
 		/**
 		 * Duplicate the given value.
@@ -188,7 +195,7 @@ namespace lua {
 			stack_scope ss;
 			push(key);
 			lua_gettable(scope::state(), -2);
-			return value();
+			return pop();
 		}
 
 		/**
@@ -220,7 +227,7 @@ namespace lua {
 				args...
 			);
 			lua_pcall(scope::state(), sizeof...(Args), 1, 0);
-			return value();
+			return pop();
 		}
 
 	private:
@@ -237,12 +244,12 @@ namespace lua {
 
 	inline value globals() {
 		lua_pushglobaltable(scope::state());
-		return value();
+		return value::pop();
 	}
 
 	inline value newtable() {
 		lua_newtable(scope::state());
-		return value();
+		return value::pop();
 	}
 
 	/**

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -25,8 +25,12 @@ namespace lua {
 	}
 
 	class scope {
-	public:
 		static lua_State* s_L;
+
+	public:
+		static lua_State* state() {
+			return s_L;
+		}
 
 		scope(lua_State* L)
 		: m_prev(s_L)
@@ -51,27 +55,27 @@ namespace lua {
 	 */
 	class value {
 		static void set_registry() {
-			lua_settable(scope::s_L, LUA_REGISTRYINDEX);
+			lua_settable(scope::state(), LUA_REGISTRYINDEX);
 		}
 
 		static void get_registry() {
-			lua_gettable(scope::s_L, LUA_REGISTRYINDEX);
+			lua_gettable(scope::state(), LUA_REGISTRYINDEX);
 		}
 
 		static void push(const int value){
-			lua_pushinteger(scope::s_L, value);
+			lua_pushinteger(scope::state(), value);
 		}
 
 		static void push(const std::string& value){
-			lua_pushlstring(scope::s_L, value.data(), value.size());
+			lua_pushlstring(scope::state(), value.data(), value.size());
 		}
 
 		static void push(const char *value){
-			lua_pushstring(scope::s_L, value);
+			lua_pushstring(scope::state(), value);
 		}
 
 		static void push(const StringPtr& value){
-			lua_pushlstring(scope::s_L, value.c, value.len);
+			lua_pushlstring(scope::state(), value.c, value.len);
 		}
 
 		static void push(const value& value);
@@ -106,7 +110,7 @@ namespace lua {
 		}
 
 		~value() {
-			lua_pushnil(scope::s_L);
+			lua_pushnil(scope::state());
 			set_registry_slot();
 		}
 
@@ -114,7 +118,7 @@ namespace lua {
 		 * Push this value's registry key.
 		 */
 		const value& key() const {
-			lua_pushlightuserdata(scope::s_L, const_cast<value*>(this));
+			lua_pushlightuserdata(scope::state(), const_cast<value*>(this));
 			return *this;
 		}
 
@@ -133,9 +137,9 @@ namespace lua {
 		std::string tostring() const {
 			push();
 			std::size_t len;
-			const char* s = lua_tolstring(scope::s_L, -1, &len);
+			const char* s = lua_tolstring(scope::state(), -1, &len);
 			std::string result(s, len);
-			lua_pop(scope::s_L, 1);
+			lua_pop(scope::state(), 1);
 			return result;
 		}
 
@@ -146,9 +150,9 @@ namespace lua {
 		value gettable(const TKey& key) const {
 			push();
 			push(key);
-			lua_gettable(scope::s_L, -2);
+			lua_gettable(scope::state(), -2);
 			value result;
-			lua_pop(scope::s_L, 1);
+			lua_pop(scope::state(), 1);
 			return result;
 		}
 
@@ -160,8 +164,8 @@ namespace lua {
 			push();
 			push(key);
 			push(value);
-			lua_settable(scope::s_L, -3);
-			lua_pop(scope::s_L, 1);
+			lua_settable(scope::state(), -3);
+			lua_pop(scope::state(), 1);
 			return *this;
 		}
 
@@ -180,7 +184,7 @@ namespace lua {
 				},
 				args...
 			);
-			lua_pcall(scope::s_L, sizeof...(Args), 1, 0);
+			lua_pcall(scope::state(), sizeof...(Args), 1, 0);
 			return value();
 		}
 
@@ -191,18 +195,18 @@ namespace lua {
 		 */
 		void set_registry_slot() {
 			key();
-			lua_rotate(scope::s_L, -2, 1);
+			lua_rotate(scope::state(), -2, 1);
 			set_registry();
 		}
 	};
 
 	inline value globals() {
-		lua_pushglobaltable(scope::s_L);
+		lua_pushglobaltable(scope::state());
 		return value();
 	}
 
 	inline value newtable() {
-		lua_newtable(scope::s_L);
+		lua_newtable(scope::state());
 		return value();
 	}
 
@@ -223,9 +227,9 @@ namespace lua {
 		const subscript_value& push() const {
 			m_table.push();
 			m_key.push();
-			lua_gettable(scope::s_L, -2);
-			lua_rotate(scope::s_L, -2, 1);
-			lua_pop(scope::s_L, 1);
+			lua_gettable(scope::state(), -2);
+			lua_rotate(scope::state(), -2, 1);
+			lua_pop(scope::state(), 1);
 			return *this;
 		}
 

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -119,6 +119,14 @@ namespace lua {
 		}
 
 		/**
+		 * Create a value for the given stack slot.
+		 */
+		static value at(const int index = -1) {
+			lua_pushvalue(scope::state(), index);
+			return pop();
+		}
+
+		/**
 		 * A nil value.
 		 */
 		value()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,7 @@ int Main(vector<string> args)
 				}
 
 				// return lua value
-				return lua::value();
+				return lua::value::pop();
 			};
 		}
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,14 +106,14 @@ int Main(vector<string> args)
 				params["tokens"] = tokens;
 
 				// find function
-				const lua::value func = lua::getglobal(*L, funcName.c_str());
+				const lua::value func(lua::globals(*L)[funcName.c_str()]);
 
 				// call lua function and return lua value.
 				return func(params).slot();
 			};
 		}
 		else{ // function not found, no default function in lua script -> just return last matched token
-			parser[rule.c_str()] = [&L, rule](const SemanticValues& sv, any&){
+			parser[rule.c_str()] = [&L](const SemanticValues& sv, any&){
 				if(sv.tokens.size() == 0){
 					lua_pushlstring(L, sv.c_str(), sv.length()); // no tokens, return matched string
 				}
@@ -145,7 +145,7 @@ int Main(vector<string> args)
 
 				// display "match", the matched string and the result of the reduction
 				cout << "match: \"" << shorten(s, matchlen, DEBUG_STRLEN-2) << "\" -> ";
-				const lua::value stringify = lua::getglobal(*L, "stringify");
+				const lua::value stringify(lua::globals(*L)["stringify"]);
 				const string output = stringify(value.get<LuaStackPtr>()).tostring();
 				cout << shorten(output.data(), output.size(), DEBUG_STRLEN) << endl;
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,14 @@
-#include <iostream>
-#include <fstream>
-#include <string>
-#include "lua/src/lua.hpp"
 #include "luautils.h"
 #include "stringutils.h"
+
 #include "peglib.h"
+
+#include "lua/src/lua.hpp"
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #define DEBUG_PARSER
 #define DEBUG_STRLEN 40 // display that many chars of the parsing text in debug output
@@ -112,8 +116,13 @@ int Main(vector<string> args)
 				// find function
 				const lua::value func(lua::globals()[funcName.c_str()]);
 
-				// call lua function and return lua value.
-				return func(params);
+				try {
+					// call lua function and return lua value.
+					return func(params);
+				} catch (lua::exception&) {
+					// Wrap the Lua exception as a runtime_error.
+					throw std::runtime_error(lua::value::pop().tostring());
+				}
 			};
 		}
 		else{ // function not found, no default function in lua script -> just return last matched token

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ int Main(vector<string> args)
 		}
 
 		if(funcName != ""){ // use the specified function or the default function from the lua script
-			parser[rule.c_str()] = [&L, rule, funcName](const SemanticValues& sv, any& dt){
+			parser[rule.c_str()] = [&L, rule, funcName](const SemanticValues& sv, any&){
 
 				// find function
 				lua_getglobal(L, funcName.c_str());
@@ -118,7 +118,7 @@ int Main(vector<string> args)
 			};
 		}
 		else{ // function not found, no default function in lua script -> just return last matched token
-			parser[rule.c_str()] = [&L, rule](const SemanticValues& sv, any& dt){
+			parser[rule.c_str()] = [&L, rule](const SemanticValues& sv, any&){
 
 				if(sv.tokens.size() == 0){
 					lua_push(L, StringPtr(sv.c_str(), sv.length())); // no tokens, return matched string
@@ -143,7 +143,7 @@ int Main(vector<string> args)
 			indent++;
 		};
 
-		parser[r.c_str()].leave = [r, &L](const char* s, size_t n, size_t matchlen, any& value, any& dt) {
+		parser[r.c_str()].leave = [r, &L](const char* s, size_t, size_t matchlen, any& value, any& dt) {
 			auto& indent = *dt.get<int*>();
 			indent--;
 			cout << repeat("|  ", indent) << "`-> ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,10 +64,10 @@ int Main(vector<string> args)
 		cerr << "error parsing grammar: there is no global string variable \"grammar\" in the lua file" << endl;
 		return EXIT_FAILURE;
 	}
-	string grammar = lua_tostring(L.get(), -1);
+	const char* const grammar = lua_tostring(L.get(), -1);
 
 	// create parser
-	parser parser(grammar.c_str());
+	parser parser(grammar);
 	if (!parser){
 		cerr << "error creating parser" << endl;
 		return EXIT_FAILURE;
@@ -83,7 +83,7 @@ int Main(vector<string> args)
 
 	// assign in-lua-defined rules
 	for(const auto& rule:rules){
-		string funcName = rule.c_str();
+		string funcName = rule;
 		lua_getglobal(L.get(), funcName.c_str()); // put pointer to function on stack
 		if(!lua_isfunction(L.get(), -1)){
 			if(foundDefault){funcName = "default";}
@@ -114,7 +114,7 @@ int Main(vector<string> args)
 				params["tokens"] = tokens;
 
 				// find function
-				const lua::value func(lua::globals()[funcName.c_str()]);
+				const lua::value func(lua::globals()[funcName]);
 
 				try {
 					// call lua function and return lua value.

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -6,12 +6,12 @@
 
 // helper for repeating output
 struct repeat{
-	repeat(const char* s_, size_t num_):s(s_), num(num_){}
+	repeat(const char* s_, std::size_t num_):s(s_), num(num_){}
 	const char* s;
-	size_t num;
+	std::size_t num;
 };
 std::ostream& operator<< (std::ostream& stream, const repeat& rep){
-	for(int i=0; i<rep.num; ++i){
+	for (std::size_t i = 0; i < rep.num; ++i){
 		stream << rep.s;
 	}
 	return stream;


### PR DESCRIPTION
This is far from a finished implementation, but it shows how to replace the use of `LuaStackPtr` as values inside the parser by a more general class. A `lua::value` wraps a value stored in Lua's registry. Thereby, it is independent of the current stack indices and can be created and destroyed at will.

Some syntactic sugar is also provided to make C++ code look more like the equivalent Lua. For example, if `v` is a `lua::value` containing a table, then `v[k]` represents the value at the given key and allows assignment to it. If `f` is a `lua::value` containing a function, then `f(a0, …)` invokes the function with the given arguments.