### PR TITLE
Pegparser class

### DIFF
--- a/src/luautils.h
+++ b/src/luautils.h
@@ -358,6 +358,68 @@ namespace lua {
 		value(msg).push();
 		throw exception();
 	}
+
+	/**
+	 * A Lua method and its name in the metatable.
+	 */
+	struct method {
+		const char* name;
+		int (&f)(lua_State*);
+	};
+
+	/**
+	 * I represent a Lua metatable and provide methods for accessing
+	 * the contained userdata.
+	 */
+	template<const char* Name, typename T>
+	class metatable {
+		static int finalize(lua_State* L) {
+			T* const t = touserdata(L);
+			const scope luascope(L);
+			t->~T();
+			return 0;
+		}
+
+	public:
+		/**
+		 * Create a new instance for this template specialisation.
+		 * The userdata remains at the top of the stack.
+		 *
+		 * @return The new instance.
+		 */
+		template<std::size_t N, typename... Args>
+		static T* newuserdata(const method (&methods)[N], Args&&... args) {
+			lua_State* const L = scope::state();
+
+			T* const t = static_cast<T*>(lua_newuserdata(L, sizeof(T)));
+
+			if (luaL_newmetatable(L, Name)) {
+				lua_pushcfunction(L, finalize);
+				lua_setfield(L, -2, "__gc");
+				lua_newtable(L);
+				for (const auto& m : methods) {
+					lua_pushcfunction(L, m.f);
+					lua_setfield(L, -2, m.name);
+				}
+				lua_setfield(L, -2, "__index");
+			}
+			lua_setmetatable(L, -2);
+
+			return new (t) T(std::forward<Args>(args)...);
+		}
+
+		/**
+		 * If the value is a userdata whose metatable matches this
+		 * template specialisation, return the instance pointer.
+		 * Otherwise, raises a Lua error and does not return.
+		 *
+		 * @param index The index of the value to check.
+		 * @return The instance pointer if valid.
+		 */
+		static T* touserdata(lua_State* const L, int index = -1) {
+			return static_cast<T*>(luaL_checkudata(L, index, Name));
+		}
+	};
 }
 
 inline auto lua_loadutils(lua_State *L){

--- a/src/luautils.h
+++ b/src/luautils.h
@@ -395,12 +395,11 @@ namespace lua {
 	public:
 		/**
 		 * Create a new instance for this template specialisation.
-		 * The userdata remains at the top of the stack.
 		 *
 		 * @return The new instance.
 		 */
 		template<std::size_t N, typename... Args>
-		static T* newuserdata(const method (&methods)[N], Args&&... args) {
+		static value newuserdata(const method (&methods)[N], Args&&... args) {
 			lua_State* const L = scope::state();
 
 			T* const t = static_cast<T*>(lua_newuserdata(L, sizeof(T)));
@@ -416,8 +415,10 @@ namespace lua {
 				lua_setfield(L, -2, "__index");
 			}
 			lua_setmetatable(L, -2);
+			const value result = lua::value::pop();
 
-			return new (t) T(std::forward<Args>(args)...);
+			new (t) T(std::forward<Args>(args)...);
+			return result;
 		}
 
 		template<value (T::*f)()>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,13 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <vector>
 #include "lua/src/lua.hpp"
 #include "luautils.h"
-#include "stringutils.h"
-#include "peglib.h"
 #include "parser.h"
 
 lua_State* lua::scope::s_L = nullptr;
 
-using namespace peg;
 using namespace std;
 
 // main

--- a/src/parser.h
+++ b/src/parser.h
@@ -4,5 +4,3 @@
 #include "luautils.h"
 
 lua::value makeParser();
-lua::value parse();
-lua::value destroyParser();

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -12,7 +12,7 @@ struct repeat{
 };
 
 inline std::ostream& operator <<(std::ostream& stream, const repeat& rep) {
-	for(int i=0; i<rep.num; ++i){
+	for(std::size_t i=0; i<rep.num; ++i){
 		stream << rep.s;
 	}
 	return stream;


### PR DESCRIPTION
This PR demonstrates how the code that creates a Lua metatable and new instances of the corresponding user data can be moved into the `lua::` library, minimising the effort required to expose host classes to Lua scripts.

Of course, with only a single class (which only has a single method), the advantages of this refactoring are minimal and there is an appreciable overall code bloat with a small reduction to the code required to expose the specific class.

Potentially, in the future there might be more exposed classes – for example, it might make sense to expose something like `peg::SemanticValue` to Lua scripts rather than passing a basic Lua table. The benefits from this refactoring would then increase.